### PR TITLE
Use `start_active_span` instead of `start_span` in ServerMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
 before_install: gem install bundler -v 1.15.4

--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -29,13 +29,13 @@ module Sidekiq
           end
 
           config.server_middleware do |chain|
-            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, active_span: active_span
+            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer
           end
         end
 
         if defined?(Sidekiq::Testing)
           Sidekiq::Testing.server_middleware do |chain|
-            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, active_span: active_span
+            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer
           end
         end
       end

--- a/sidekiq-opentracing.gemspec
+++ b/sidekiq-opentracing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.4'
   spec.add_dependency 'sidekiq'
 
   spec.add_development_dependency "opentracing_test_tracer", "~> 0.1"

--- a/sidekiq-opentracing.gemspec
+++ b/sidekiq-opentracing.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentracing', '~> 0.3.1'
   spec.add_dependency 'sidekiq'
 
-  spec.add_development_dependency "test-tracer", "~> 1.0", ">= 1.2.1"
-  spec.add_development_dependency "tracing-matchers", "~> 1.0", ">= 1.3.0"
+  spec.add_development_dependency "opentracing_test_tracer", "~> 0.1"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/sidekiq/tracer/server_middleware_spec.rb
+++ b/spec/sidekiq/tracer/server_middleware_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Sidekiq::Tracer::ServerMiddleware do
-  let(:tracer) { Test::Tracer.new }
+  let(:tracer) { OpenTracingTestTracer.build }
 
   describe "auto-instrumentation" do
     before do
@@ -11,31 +11,31 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
     end
 
     it "creates a new span" do
-      expect(tracer).to have_spans(1)
+      expect(tracer.spans.count).to eq(1)
     end
 
     it "sets operation_name to job name" do
-      expect(tracer).to have_span("TestJob")
+      expect(tracer.spans.first.operation_name).to eq("TestJob")
     end
 
     it "sets standard OT tags" do
-      [
-        ['component', 'Sidekiq'],
-        ['span.kind', 'server']
-      ].each do |key, value|
-        expect(tracer).to have_span.with_tag(key, value)
-      end
+      span = tracer.spans.first
+
+      expect(span.tags).to include(
+        'component' => 'Sidekiq',
+        'span.kind' => 'server'
+      )
     end
 
     it "sets Sidekiq specific OT tags" do
-      [
-        ['sidekiq.queue', 'default'],
-        ['sidekiq.retry', "true"],
-        ['sidekiq.args', "value1, value2, 1"],
-        ['sidekiq.jid', /\S+/]
-      ].each do |key, value|
-        expect(tracer).to have_span.with_tag(key, value)
-      end
+      span = tracer.spans.first
+
+      expect(span.tags).to include(
+        'sidekiq.queue' => 'default',
+        'sidekiq.retry' => 'true',
+        'sidekiq.args' => 'value1, value2, 1',
+        'sidekiq.jid' => /\S+/
+      )
     end
   end
 
@@ -50,18 +50,21 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
     end
 
     it "creates spans for each part of the chain" do
-      expect(tracer).to have_spans(3)
+      expect(tracer.spans.count).to eq(3)
     end
 
     it "all spans contains the same trace_id" do
-      expect(tracer).to have_traces(1)
+      trace_ids = tracer.spans.map(&:context).map(&:trace_id).uniq
+
+      expect(trace_ids.count).to eq(1)
     end
 
     it "propagates parent child relationship properly" do
-      client_span = tracer.finished_spans[0]
-      server_span = tracer.finished_spans[1]
-      expect(client_span).to be_child_of(root_span)
-      expect(server_span).to be_child_of(client_span)
+      client_span = tracer.spans[1]
+      server_span = tracer.spans[2]
+
+      expect(client_span.context.parent_id).to eq(root_span.context.span_id)
+      expect(server_span.context.parent_id).to eq(client_span.context.span_id)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
 require "bundler/setup"
-require "tracing-matchers"
 require "sidekiq/testing"
 require "sidekiq-opentracing"
+require 'opentracing_test_tracer'
 require "pry"
+
+OpenTracing.global_tracer = OpenTracingTestTracer.build
 
 Sidekiq::Testing.fake!
 


### PR DESCRIPTION
start_active_span changes the active span of the tracer, which allows
Sidekiq worker to access the server span.