### PR TITLE
Upgrade opentracing dependency

### DIFF
--- a/sidekiq-opentracing.gemspec
+++ b/sidekiq-opentracing.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.5.0'
   spec.add_dependency 'sidekiq'
 
   spec.add_development_dependency "test-tracer", "~> 1.0", ">= 1.2.1"


### PR DESCRIPTION
In the same spirit as https://github.com/iaintshine/ruby-grpc-opentracing/pull/6, this upgrades the `opentracing` dependency.